### PR TITLE
Use logger interface for middleware

### DIFF
--- a/src/Middleware/LoggingMiddleware.php
+++ b/src/Middleware/LoggingMiddleware.php
@@ -8,13 +8,13 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
-use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 class LoggingMiddleware implements MiddlewareInterface
 {
-    private Logger $logger;
+    private LoggerInterface $logger;
 
-    public function __construct(Logger $logger)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use DI\Container;
 use Psr\Container\ContainerInterface;
 use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\RotatingFileHandler;
 use Illuminate\Database\Capsule\Manager as Capsule;
@@ -57,6 +58,11 @@ return function (Container $container) {
             $fallbackLogger->error('Failed to create logger with configured handlers: ' . $e->getMessage());
             return $fallbackLogger;
         }
+    });
+
+    // Allow retrieving logger via interface
+    $container->set(LoggerInterface::class, function (Container $c) {
+        return $c->get(Logger::class);
     });
 
     // Database


### PR DESCRIPTION
## Summary
- initialize container dependencies before app creation
- inject PSR logger interface into LoggingMiddleware and expose logger through interface binding

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a18f00ddb4832291c81ba7e2a76ce5